### PR TITLE
Fix issue: #31 (setup crony during OCP installation)

### DIFF
--- a/examples/install_vars.yaml
+++ b/examples/install_vars.yaml
@@ -18,3 +18,11 @@ proxy_url: ""
 no_proxy: ""
 
 enable_local_registry: false
+
+chronyconfig:
+   enabled: false
+   content:
+     - server: ntp1.example.com
+       options: iburst
+     - server: ntp2.example.com
+       options: iburst

--- a/playbooks/roles/ocp-config/README.md
+++ b/playbooks/roles/ocp-config/README.md
@@ -25,6 +25,20 @@ Role Variables
 | proxy_url               | no       | ""             | Proxy url eg: http://[user:passwd@]server:port (NA when setup_squid_proxy: true)|
 | no_proxy                | no       | ""             | Comma seperated string of domains/cidr to exclude proxy |
 | enable_local_registry   | no       | false          | Set to true to enable usage of local registry for restricted network install |
+| chronyconfig.enabled    | no       | flase          | Set to true to enable chrony configuration on the coreOS node during install |
+| chronyconfig.content    | no       | ""             | List of time servers and options pair (see chronyconfig examples) |
+
+*chronyconfig variable example *
+
+```yaml
+chronyconfig:
+   enabled: true
+   content:
+     - server: ntp1.example.com
+       options: iburst
+     - server: ntp2.example.com
+       options: iburst
+```
 
 Dependencies
 ------------

--- a/playbooks/roles/ocp-config/defaults/main/main.yaml
+++ b/playbooks/roles/ocp-config/defaults/main/main.yaml
@@ -8,3 +8,5 @@ proxy_url: ""
 no_proxy: ""
 enable_local_registry: false
 
+chronyconfig:
+   enabled: false

--- a/playbooks/roles/ocp-config/files/update_ignition_bootstrap.py
+++ b/playbooks/roles/ocp-config/files/update_ignition_bootstrap.py
@@ -16,7 +16,7 @@ files.append(
         'source': 'data:text/plain;charset=utf-8;base64,' + dhcp_client_conf_b64,
         'verification': {}
         },
-    'filesystem': 'root',
+    'filesystem': 'root'
 })
 
 dhclient_cont_b64 = base64.standard_b64encode(b'send dhcp-client-identifier = hardware;\nprepend domain-name-servers 127.0.0.1;\n').decode().strip()
@@ -30,6 +30,23 @@ files.append(
         },
     'filesystem': 'root'
 })
+
+if os.path.isfile('/tmp/chrony.conf.tmp'):
+    with open("/tmp/chrony.conf.tmp", "rb") as chronyconf:
+        chrony_b64 = base64.standard_b64encode(chronyconf.read()).decode().strip()
+        files.append(
+        {
+            'path': '/etc/chrony.conf',
+            'user': {
+                'name': 'root'
+            },
+            'mode': 420,
+            'contents': {
+                'source': 'data:text/plain;charset=utf-8;base64,' + chrony_b64,
+                'verification': {}
+                },
+            'filesystem': 'root'
+        })
 
 ignition['storage']['files'] = files;
 

--- a/playbooks/roles/ocp-config/tasks/chrony.yaml
+++ b/playbooks/roles/ocp-config/tasks/chrony.yaml
@@ -1,0 +1,17 @@
+- name: Create temporary chrony.conf file
+  template:
+    src: chrony.conf.j2
+    dest: /tmp/chrony.conf.tmp
+
+- name: slurp contents of temporary chrony.conf file
+  slurp:
+    src: /tmp/chrony.conf.tmp
+  register: chronybase64
+
+- name: Generate Chrony machineconfig
+  template:
+    src: chrony-machineconfig.j2
+    dest: "{{ workdir }}/manifests/99-{{item}}-chrony-configuration.yaml"
+  loop: 
+    - master
+    - worker

--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -107,6 +107,10 @@
     line: '\1mastersSchedulable: False'
     backrefs: yes
 
+- name: Create Chrony machineconfig files for coreOS
+  import_tasks: chrony.yaml
+  when: chronyconfig.enabled
+
 - name: Create ignition files
   shell: "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
   args:

--- a/playbooks/roles/ocp-config/templates/chrony-machineconfig.j2
+++ b/playbooks/roles/ocp-config/templates/chrony-machineconfig.j2
@@ -1,0 +1,25 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{item}}
+  name: 99-{{item}}-chrony-configuration
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ chronybase64.content }}
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/chrony.conf
+  osImageURL: ""

--- a/playbooks/roles/ocp-config/templates/chrony-machineconfig.j2
+++ b/playbooks/roles/ocp-config/templates/chrony-machineconfig.j2
@@ -23,4 +23,3 @@ spec:
         mode: 420
         path: /etc/chrony.conf
   osImageURL: ""
-  

--- a/playbooks/roles/ocp-config/templates/chrony-machineconfig.j2
+++ b/playbooks/roles/ocp-config/templates/chrony-machineconfig.j2
@@ -23,3 +23,4 @@ spec:
         mode: 420
         path: /etc/chrony.conf
   osImageURL: ""
+  

--- a/playbooks/roles/ocp-config/templates/chrony.conf.j2
+++ b/playbooks/roles/ocp-config/templates/chrony.conf.j2
@@ -1,0 +1,7 @@
+{% for item in chronyconfig.content %}
+server {{ item.server }} {{ item.options }}
+{% endfor %}
+driftfile /var/lib/chrony/drift
+makestep 1.0 3
+rtcsync
+logdir /var/log/chrony


### PR DESCRIPTION
 - Allow users to specify a list of ntp servers to configure chrony time
synchronization on coreOS node during installation. (bootstrap, workers, masters)

This will avoid certificates rejection due to time difference between servers.