### PR TITLE
Fix #26: deploy powervm-rmc daemonset during ocp-customization

### DIFF
--- a/playbooks/roles/ocp-customization/README.md
+++ b/playbooks/roles/ocp-customization/README.md
@@ -25,6 +25,7 @@ Role Variables
 | workdir                 | no       | ~/ocp4-workdir | Place for config generation and auth files  |
 | rhcos_kernel_options    | no       | []             | List of kernel options for RHCOS nodes eg: ["slub_max_order=0","loglevel=7"] |
 | sysctl_tuned_options    | no       | false       | Set to true to apply sysctl options via tuned operator |
+| powervm_rmc             | no       | true           | Set to true to deploy RMC daemonset on Node with arch ppc64le |
 
 
 If `sysctl_tuned_options` is true then the following variables are must and should be set in [vars/tuned.yaml](./vars/tuned.yaml)

--- a/playbooks/roles/ocp-customization/defaults/main.yaml
+++ b/playbooks/roles/ocp-customization/defaults/main.yaml
@@ -4,4 +4,5 @@
 workdir: ~/ocp4-workdir
 rhcos_kernel_options: []
 sysctl_tuned_options: false
+powervm_rmc: true
 

--- a/playbooks/roles/ocp-customization/tasks/main.yaml
+++ b/playbooks/roles/ocp-customization/tasks/main.yaml
@@ -1,10 +1,44 @@
----
 # tasks file for ocp4 post install customizations
+- name: Install openshift python module
+  pip:
+    executable: pip3
+    name: openshift
 
-- name: Configure RHCOS kernel options via MachineConfig
-  when: rhcos_kernel_options | length > 0
-  import_tasks: kernel.yaml
+- name:
+  block:
+    - name: Pause reboot node (Machineconfig)
+      k8s:
+        merge_type: merge
+        kind: MachineConfigPool
+        name: "{{ item }}"
+        definition:
+          spec:
+            paused: true
+      loop:
+        - master
+        - worker
 
-- name: Configure Kernel tunables (sysctl) via Tuned Operator
-  when: sysctl_tuned_options
-  import_tasks: tuned.yaml
+    - name: Configure RHCOS kernel options via MachineConfig
+      when: rhcos_kernel_options | length > 0
+      import_tasks: kernel.yaml
+
+    - name: Configure Kernel tunables (sysctl) via Tuned Operator
+      when: sysctl_tuned_options
+      import_tasks: tuned.yaml
+
+    - name: Configure PowerVM RMC daemonset
+      when: powervm_rmc
+      import_tasks: powervm_rmc.yaml
+
+  always:
+    - name: UnPause reboot node (Machineconfig)
+      k8s:
+        merge_type: merge
+        kind: MachineConfigPool
+        name: "{{ item }}"
+        definition:
+          spec:
+            paused: false
+      loop:
+        - master
+        - worker

--- a/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
+++ b/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
@@ -1,0 +1,106 @@
+- name: Install openshift python module
+  pip:
+    executable: pip3
+    name: openshift
+
+- name: Create powervm-rmc project
+  k8s:
+    name: powervm-rmc
+    api_version: project.openshift.io/v1
+    kind: Project
+    state: present
+
+- name: Create powervm-rmc project
+  k8s:
+    name: powervm-rmc
+    api_version: project.openshift.io/v1
+    kind: Project
+    state: present
+
+- name: Create powervm-rmc serviceaccount
+  k8s:
+    state: present
+    definition:
+      api_version: v1
+      kind: ServiceAccount
+      metadata:
+        name: powervm-rmc
+        namespace: powervm-rmc
+
+- name: Add privileged scc to powervm-rmc serviceaccount
+  shell: "oc adm policy add-scc-to-user -z powervm-rmc privileged -n powervm-rmc"
+
+- name: Deploy powervm-rmc DaemonSet
+  k8s:
+    state: present
+    definition:
+      kind: DaemonSet
+      apiVersion: apps/v1
+      metadata:
+        name: powervm-rmc
+        namespace: powervm-rmc
+      spec:
+        selector:
+          matchLabels:
+            app: powervm-rmc
+        template:
+          metadata:
+            creationTimestamp: null
+            labels:
+              app: powervm-rmc
+          spec:
+            nodeSelector:
+              kubernetes.io/arch: ppc64le
+              node.openshift.io/os_id: rhcos
+            restartPolicy: Always
+            serviceAccountName: powervm-rmc
+            hostNetwork: true
+            containers:
+              - name: powervm-rmc
+                image: 'quay.io/powercloud/rsct-ppc64le:latest'
+                ports:
+                  - name: rmc-tcp
+                    hostPort: 657
+                    containerPort: 657
+                    protocol: TCP
+                  - name: rmc-udp
+                    hostPort: 657
+                    containerPort: 657
+                    protocol: UDP
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 1Gi
+                securityContext:
+                  privileged: true
+                  runAsUser: 0
+            serviceAccount: powervm-rmc
+            tolerations:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+                effect: NoSchedule
+
+- name: Loading rpadlpar_io module at boot via Machineconfig
+  k8s:
+    state: present
+    definition:
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: "{{ item }}"
+        name: "50-{{ item }}-powervm-rmc-modules"
+      spec:
+        config:
+          ignition:
+            version: 2.2.0
+          storage:
+            files:
+            - contents:
+                source: data:text/plain;charset=utf-8;base64,cnBhZGxwYXJfaW8K
+              filesystem: root
+              mode: 0644
+              path: /etc/modules-load.d/powervm-rmc.conf
+  loop:
+    - master
+    - worker


### PR DESCRIPTION
Signed-off-by: Sebastien Chabrolles <s.chabrolles@fr.ibm.com>

* This uses k8s ansible module in order to apply k8s yaml in an idempotent and efficient way (need openshift python module to be installed on the bastion.
* namespace creation, serviceaccount creation and daemonset creation use yaml and k8s ansible module.
giving "privileged" right to powervm-rmc service account is done via oc command (I don't find how to use yaml for this)
* Need to load rpadlpar_io module on coreOS node to enable DLPAR for IO card (like veth, NPIV or SRIOV, or even Real PCI card). This is done with another Machineconfig for master and worker roles.