### PR TITLE
Adding worker nodes to the OCP 4 UPI cluster existing 24+ hours

### DIFF
--- a/playbooks/roles/ocp-install/tasks/main.yaml
+++ b/playbooks/roles/ocp-install/tasks/main.yaml
@@ -40,18 +40,29 @@
         openssl s_client -connect $MCS  -showcerts                      | \
         awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' | \
         base64 --wrap=0                                                 | \
-        tee ./api-int.base64 && sed --regexp-extended --in-place=.backup "s%base64,[^,]+%base64,$(cat ./api-int.base64)\"%" ./worker.ign
+        tee api-int.base64 && sed --regexp-extended --in-place=.backup "s%base64,[^,]+%base64,$(cat api-int.base64)\"%" openstack-upi/worker.ign
     
         # Copy Ignition Files to HTTP server
         cp openstack-upi/worker.ign /var/www/html/ignition
         chmod 777 /var/www/html/ignition/*.ign
     fi
+
+- name: total workers to be instantiated
+  shell: cat /etc/dhcp/dhcpd.conf | grep worker | wc -l | tr -d ' '
+  register: total_count
+
+- debug: 
+    msg: "worker_count is {{ worker_count }}"
+         
+- debug: 
+    msg: "total_count is {{ total_count }}"
+  
     
 # Run approve command till we have all workers ready. 'xargs -r ' is used to ignore empty stdin.
 - name: Approve Worker CSRs
   shell: |
     oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' | xargs -r oc adm certificate approve
-  until: lookup('pipe','oc get nodes | grep -w worker | grep -w Ready | grep  -v "NotReady" |wc -l') == worker_count
+  until: lookup('pipe','oc get nodes | grep -w worker | grep -w Ready | grep  -v "NotReady" |wc -l') == total_count
   retries: 30
   delay: 60
   when: worker_count|int > 0

--- a/playbooks/roles/ocp-install/tasks/main.yaml
+++ b/playbooks/roles/ocp-install/tasks/main.yaml
@@ -11,11 +11,47 @@
     src: "{{ workdir }}/auth/kubeconfig"
     dest: "~/.kube/config"
 
+- name: Update a certificate if required
+  shell: |
+    hostname=`hostname`
+    DOMAIN=${hostname%"-bastion-0.ibm.com"}
+
+    # check if the cluster is more than 24 hrs old
+    if ( ! type -P oc ); then exit 0; fi
+      # get the cluster create time in seconds
+      oc get -o json clusterversion version > /tmp/test.$$ 2> /dev/null
+      tmstmp_str=$(cat /tmp/test.$$ | jq -r '.metadata.creationTimestamp')
+      tmstmp=`date -d$tmstmp_str +%s`
+  
+      # if the cluster time greater than 24 hrs then update the ecrtificate
+      if (( $tmstmp  + 86400 < `date +%s` )); then
+
+        #preserve the timestamp of the file
+        echo "create a new certificate"
+        if [ ! -f openstack-upi/.worker.ign.backup ]; then
+          cp -p openstack-upi/worker.ign openstack-upi/.worker.ign.backup
+        fi
+
+        # update the tls certificate in the worker ignition file
+        URL=api-int.${DOMAIN}
+        MCS=api-int.${DOMAIN}:22623
+
+        echo "q"                                                        | \
+        openssl s_client -connect $MCS  -showcerts                      | \
+        awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' | \
+        base64 --wrap=0                                                 | \
+        tee ./api-int.base64 && sed --regexp-extended --in-place=.backup "s%base64,[^,]+%base64,$(cat ./api-int.base64)\"%" ./worker.ign
+    
+        # Copy Ignition Files to HTTP server
+        cp openstack-upi/worker.ign /var/www/html/ignition
+        chmod 777 /var/www/html/ignition/*.ign
+    fi
+    
 # Run approve command till we have all workers ready. 'xargs -r ' is used to ignore empty stdin.
 - name: Approve Worker CSRs
   shell: |
     oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' | xargs -r oc adm certificate approve
-  until: lookup('pipe','oc get nodes | grep -w worker | grep -w Ready | wc -l') == worker_count
+  until: lookup('pipe','oc get nodes | grep -w worker | grep -w Ready | grep  -v "NotReady" |wc -l') == worker_count
   retries: 30
   delay: 60
   when: worker_count|int > 0

--- a/playbooks/roles/ocp-install/tasks/main.yaml
+++ b/playbooks/roles/ocp-install/tasks/main.yaml
@@ -17,7 +17,7 @@
     DOMAIN=${hostname%"-bastion-0.ibm.com"}
 
     # check if the cluster is more than 24 hrs old
-    if ( ! type -P oc ); then exit 0; fi
+    if ( type -P oc ); then 
       # get the cluster create time in seconds
       oc get -o json clusterversion version > /tmp/test.$$ 2> /dev/null
       tmstmp_str=$(cat /tmp/test.$$ | jq -r '.metadata.creationTimestamp')
@@ -45,6 +45,7 @@
         # Copy Ignition Files to HTTP server
         cp openstack-upi/worker.ign /var/www/html/ignition
         chmod 777 /var/www/html/ignition/*.ign
+      fi
     fi
 
 - name: total workers to be instantiated

--- a/playbooks/roles/ocp-install/tasks/main.yaml
+++ b/playbooks/roles/ocp-install/tasks/main.yaml
@@ -49,7 +49,10 @@
 
 - name: total workers to be instantiated
   shell: cat /etc/dhcp/dhcpd.conf | grep worker | wc -l | tr -d ' '
-  register: total_count
+  register: total_count_str
+
+- set_fact:
+    total_count={{ total_count_str.stdout }}
 
 - debug: 
     msg: "worker_count is {{ worker_count }}"
@@ -65,7 +68,7 @@
   until: lookup('pipe','oc get nodes | grep -w worker | grep -w Ready | grep  -v "NotReady" |wc -l') == total_count
   retries: 30
   delay: 60
-  when: worker_count|int > 0
+  when: total_count|int > 0
 
 - name: Wait for install-complete
   shell: "openshift-install wait-for install-complete --log-level {{ log_level }}"


### PR DESCRIPTION
If the cluster is older than a day, the bootstrap certificate has to be updated. This code takes care of this issue. 
Also on other note, if the worker node count is decreased then the removed worker node is put in NotReady state. The loop where CSR is approved takes care of this.
And lastly we will like to make kubeconfig available in bastion .kube directory in the beginning itself, otherwise the oc command does not work.