### PR TITLE
Adding worker nodes to the OCP 4 UPI cluster existing 24+ hours

### DIFF
--- a/playbooks/roles/ocp-install/tasks/checkcert.yaml
+++ b/playbooks/roles/ocp-install/tasks/checkcert.yaml
@@ -1,0 +1,54 @@
+---
+# tasks file for ocp4 install cert
+
+- name: check if oc is installed
+  command: type -P oc
+  register: oc_installed
+
+# if cluster is over 24 hrs. old set over24 to 1
+- name: check the cluster timestamp
+  shell: |
+    # get the cluster create time in seconds
+    tmstmp=`date -d$(oc get -o json clusterversion -o jsonpath={.items[0].metadata.creationTimestamp}) '+%s'`
+    echo $(( $tmstmp  + 86400 < `date +%s` ? 1:0 ))
+  register: over24
+  when: oc_installed.rc == 0
+
+# check certificate validity
+# cert_valid is 1 if current time is in certificate validity time period, 0 otherwise
+- name: check the certificate validity
+  shell: |
+    dates=$(jq .ignition.security.tls.certificateAuthorities[].source openstack-upi/worker.ign |
+            sed -n -e  's/^\"data:text\/plain;charset=utf-8;base64,\(.*\)\"/\1/p' |
+            base64 --decode |
+            openssl x509 -noout -in - -dates)
+
+    notBefore=$(echo "${dates}" | sed -n -e 's/^notBefore=//p' | (read nb; date -d "${nb}" +%s))
+    notAfter=$(echo "${dates}" | sed -n -e 's/^notAfter=//p' | (read na; date -d "${na}" +%s))
+    present=`date +%s`
+
+    if (( $present > ${notBefore} )) && (( $present < ${notAfter} )); then
+       echo 1
+    else
+       echo 0
+    fi
+  register: cert_valid
+
+# update worker.ign file with new cert on HTTP Server if the certifiacte is invalid.
+# providing a failsafe mechanism by checking certificate validity or cluster age to determine if worker.ign requires new certificate.
+# update to worker.ign is based on redhat solution  https://access.redhat.com/solutions/4799921
+- name: Update worker ignition with new certificate if required
+  shell: |
+    MCS=api-int.{{ install_config.cluster_id }}.{{ install_config.cluster_domain }}:22623
+    cp -n openstack-upi/worker.ign openstack-upi/worker.ign.original
+
+    # update the tls certificate in the worker ignition file
+    echo "q"                                                        | \
+    openssl s_client -connect $MCS  -showcerts                      | \
+    awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/' | \
+    base64 --wrap=0                                                 | \
+    tee api-int.base64 && sed --regexp-extended --in-place=.backup "s%base64,[^,]+%base64,$(cat api-int.base64)\"}]}}%" openstack-upi/worker.ign
+
+    # Copy Ignition Files to HTTP server
+    cp -f openstack-upi/worker.ign /var/www/html/ignition
+  when: cert_valid.stdout == "0" or over24.stdout == "1"

--- a/playbooks/roles/ocp-install/tasks/main.yaml
+++ b/playbooks/roles/ocp-install/tasks/main.yaml
@@ -11,6 +11,8 @@
     src: "{{ workdir }}/auth/kubeconfig"
     dest: "~/.kube/config"
 
+- include_tasks: checkcert.yaml
+
 # Run approve command till we have all workers ready. 'xargs -r ' is used to ignore empty stdin.
 - name: Approve Worker CSRs
   shell: |


### PR DESCRIPTION
1. If the cluster is older than a day, the bootstrap certificate has to be updated. This code takes care of this issue.
2. If the worker node count is decreased then the removed worker node is put in NotReady state. The loop where CSR is approved takes care of this.
3. kubeconfig is made available in bastion's ~/.kube directory in the beginning itself, otherwise the oc command does not work.