### PR TITLE
Allow customization of networkType cni

### DIFF
--- a/playbooks/roles/ocp-config/README.md
+++ b/playbooks/roles/ocp-config/README.md
@@ -30,6 +30,7 @@ Role Variables
 | chronyconfig.content    | no       | ""             | List of time NTP servers and options pair (see chronyconfig examples). If empty, bastion will try sync with some default ntp server (internet) AND local HW clock (with higher stratum). |
 | chronyconfig.allow      | no       | ""             | List of network cidr (X.X.X.X/Y) allowed to sync with bastion configured as NTP server |
 | dhcp_shared_network     | no       |                | Flag to update DHCP server work on a shared network. (Neither ACK nor NACK unknown clients) |
+| cni_network_provider    | no       | OpenshiftSDN   | Sets the default Container Network Interface (CNI) network provider for the cluster |
 
 *chronyconfig variable example *
 

--- a/playbooks/roles/ocp-config/defaults/main/main.yaml
+++ b/playbooks/roles/ocp-config/defaults/main/main.yaml
@@ -10,3 +10,5 @@ enable_local_registry: false
 
 chronyconfig:
    enabled: true
+
+cni_network_provider: OpenshiftSDN

--- a/playbooks/roles/ocp-config/templates/install-config.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/install-config.yaml.j2
@@ -17,7 +17,7 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  networkType: OpenShiftSDN
+  networkType: {{ cni_network_provider }}
   serviceNetwork:
   - 172.30.0.0/16
 platform:


### PR DESCRIPTION
This will allow user to set the default cni network provider such as OpenshiftSDN or OVNKubernetes.

Signed-off-by: Pravin Dsilva <pravin.d-silva@ibm.com>