### PR TITLE
update ocp4-helper/machineconfig path

### DIFF
--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -82,7 +82,7 @@
       dest: "{{ workdir }}/manifests"
       remote_src: yes
     with_fileglob:
-      - "/machineconfig/*-chrony-configuration.yaml"
+      - "../../../../../ocp4-helpernode/machineconfig/*-chrony-configuration.yaml"
     when: chronyconfig.enabled
 
   - name: Create ignition files


### PR DESCRIPTION
HI, just to correct a bug introduce with 1ffcf9a.

The machine config generated by helpernode is note located into the current repo.
When using with ocp4-upi-powervm, the ocp4-helpernode repo is located in the home dir at the same level than ocp4-palybook.
