### PR TITLE
do not comment deny unknown server

### DIFF
--- a/playbooks/roles/ocp-config/tasks/dhcpd_update.yaml
+++ b/playbooks/roles/ocp-config/tasks/dhcpd_update.yaml
@@ -13,7 +13,6 @@
       sed -i.bak '/pool {/d' /etc/dhcp/dhcpd.conf
       sed -i '/range /d' /etc/dhcp/dhcpd.conf
       sed -i '$d' /etc/dhcp/dhcpd.conf
-      sed -i 's/deny unknown-clients/#deny unknown-clients/' /etc/dhcp/dhcpd.conf
     args:
       warn: false
 


### PR DESCRIPTION
I just wonder why `deny unknown-clients` is commented as it seems to exactly what you want to achieve => using several ocp installation in a shared network (each with its own bastion/DHCP) 