### PR TITLE
add clusterNetwork_CIDR and serviceNetwork variables

### DIFF
--- a/playbooks/roles/ocp-config/defaults/main/main.yaml
+++ b/playbooks/roles/ocp-config/defaults/main/main.yaml
@@ -12,3 +12,6 @@ chronyconfig:
    enabled: true
 
 cni_network_provider: OpenshiftSDN
+
+cluster_network_cidr: 10.128.0.0/14
+service_network: 172.30.0.0/16

--- a/playbooks/roles/ocp-config/templates/cluster-network-03-config.yml.j2
+++ b/playbooks/roles/ocp-config/templates/cluster-network-03-config.yml.j2
@@ -4,10 +4,10 @@ metadata:
   name: cluster
 spec: 
   clusterNetwork:
-  - cidr: 10.128.0.0/14
+  - cidr: {{ cluster_network_cidr }}
     hostPrefix: 23
   serviceNetwork:
-  - 172.30.0.0/16
+  - {{ service_network }}
   defaultNetwork:
     type: {{ cni_network_provider }}
 {% if cni_network_provider == "OVNKubernetes" %}

--- a/playbooks/roles/ocp-config/templates/install-config.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/install-config.yaml.j2
@@ -15,11 +15,11 @@ metadata:
   name: {{ install_config.cluster_id }}
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14
+  - cidr: {{ cluster_network_cidr }}
     hostPrefix: 23
   networkType: {{ cni_network_provider }}
   serviceNetwork:
-  - 172.30.0.0/16
+  - {{ service_network }}
 platform:
   none: {}
 sshKey: '{{ install_config.public_ssh_key }}'


### PR DESCRIPTION
Add the possibility to choose clusterNetwork and service Network CIDR.
(which is mandatory for implementing multicluster networking with RHACM and submariner)