### PR TITLE
Set the MTU of each node's network interfaces.

### DIFF
--- a/examples/10-setmtu.link
+++ b/examples/10-setmtu.link
@@ -1,0 +1,22 @@
+[Match]
+
+# Edit or add one line for each node containing
+# the MAC address of the interfaces.
+#
+MACAddress=ea:ad:f9:70:cf:00
+MACAddress=ea:ad:f0:4f:34:00
+MACAddress=ea:ad:f8:1f:75:00
+MACAddress=ea:ad:f2:f1:a3:00
+MACAddress=ea:ad:fc:89:3c:01
+MACAddress=ea:ad:f0:ca:81:00
+
+# Optional: set a pci-bus address with
+# a glob pattern that will select the interfaces
+# on all nodes.  This may not work in all situations.
+#
+# Path=pci-0033:01:00.*
+
+# Link properties
+[Link]
+# Set the MTU value
+MTUBytes=9000

--- a/playbooks/roles/ocp-config/files/inject_file_into_ignition.py
+++ b/playbooks/roles/ocp-config/files/inject_file_into_ignition.py
@@ -1,0 +1,60 @@
+import base64
+import json
+import os
+import sys
+
+# inject_file_into_ignition.py
+#
+# Update an ignition file with a file to be added onto a target host.
+# Usage:  python3 inject_file_into_ignition.py <ignition> <file> <path>
+# ignition: Path to ignition file to be updated.
+# file: File to be injected.
+# path: Full path to place the new file on the target host, including
+# the file name.
+
+with open(str(sys.argv[1]), 'r') as f:
+    ignition = json.load(f)
+
+if os.path.isfile(sys.argv[2]):
+    cfg = open(str(sys.argv[2]), 'rb')
+    cfg_b64 = base64.standard_b64encode(cfg.read()).decode().strip()
+else:
+    print("File:", sys.argv[2], "not found - skipping")
+    sys.exit(0)
+
+if 'storage' not in ignition:
+    newfile =( { "files": [
+        {
+            'path': str(sys.argv[3]),
+            'user': {
+                'name': 'root'
+            },
+            'mode': 420,
+            'contents': {
+                'source': 'data:text/plain;charset=utf-8;base64,' + cfg_b64 }
+         }]} )
+
+    ignition["storage"]=newfile
+
+else:
+    files = ignition['storage'].get('files', [])
+    files.append(
+        {
+            'path': str(sys.argv[3]),
+            'user': {
+                'name': 'root'
+            },
+            'mode': 420,
+            'contents': {
+                'source': 'data:text/plain;charset=utf-8;base64,' + cfg_b64,
+                'verification': {}
+                },
+            'overwrite': True
+        })
+
+# debuging
+# json.dump(ignition, sys.stdout, indent=4)
+
+print("Updating:",sys.argv[1]);
+with open(sys.argv[1], 'w') as f:
+     json.dump(ignition, f)

--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -105,6 +105,27 @@
     args:
       chdir: "{{ workdir }}"
 
+  - name: Copy inject_file_into_ignition.py
+    template:
+      src: ../files/inject_file_into_ignition.py
+      dest: /tmp/inject_file_into_ignition.py
+      mode: '0755'
+
+  - name: Update bootstrap ignition
+    shell: "python3 /tmp/inject_file_into_ignition.py bootstrap.ign /tmp/10-setmtu.link /etc/systemd/network/10-setmtu.link"
+    args:
+      chdir: "{{ workdir }}"
+
+  - name: Update master ignition
+    shell: "python3 /tmp/inject_file_into_ignition.py master.ign /tmp/10-setmtu.link /etc/systemd/network/10-setmtu.link"
+    args:
+      chdir: "{{ workdir }}"
+
+  - name: Update network for worker ignition
+    shell: "python3 /tmp/inject_file_into_ignition.py worker.ign /tmp/10-setmtu.link /etc/systemd/network/10-setmtu.link"
+    args:
+      chdir: "{{ workdir }}"
+
   - name: Host ignition files
     copy:
       src: "{{ item }}"


### PR DESCRIPTION
In some visualized environments (such as IBM's Powervm) Node to Node
network throughput via the vxlan tunnel can be substantially improved
by setting the MTU to a large value. This must be used in conjunction
with setting cni_network_mtu. With vxlan the cni_network_mtu is set 50
less than the MTU. For example if MTU=9000 then cni_network_mtu=8950.

Instructions: .
1. Set cni_network_mtu in vars.yaml.
2. Edit example/10-setmtu.link to match your config.
3. Copy 10-setmtu.link to /tmp
4. Perform cluster install as usual.

Signed-off-by: David J. Wilder <dwilder@us.ibm.com>