### PR TITLE
fix: rmc project create workaround #161

### DIFF
--- a/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
+++ b/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
@@ -1,4 +1,12 @@
+- name: Insure able to fetch project list
+  shell: "oc get projects"
+  register: projects_list
+  until: projects_list.stdout.find("default") != -1
+  retries: 60
+  delay: 5
+    
 - name: Create powervm-rmc project
+  when: projects_list.stdout.find("powervm-rmc") == -1
   k8s:
     name: powervm-rmc
     api_version: project.openshift.io/v1

--- a/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
+++ b/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
@@ -2,8 +2,8 @@
   shell: "oc get projects"
   register: projects_list
   until: projects_list.stdout.find("default") != -1
-  retries: 60
-  delay: 5
+  retries: 20
+  delay: 30
     
 - name: Create powervm-rmc project
   when: projects_list.stdout.find("powervm-rmc") == -1


### PR DESCRIPTION
This adds a simple check to make sure the project list can be fetched prior to attempting to create the powervm-rmc project.  While not needed for a normal deploy with 3 masters, if performing a single node deploy this is needed for the provisioning to go through without manual intervention. It would be better if we did not need to maintain a separate copy of this repository for this singular purpose. 

Sample output from a run:

module.install.null_resource.install (remote-exec): TASK [ocp-customization : Apply the tuned CRDs] ********************************
module.install.null_resource.install (remote-exec): skipping: [cecc-11579-bastion-0] => {"changed": false, "skip_reason": "Conditional result was False"}

module.install.null_resource.install (remote-exec): TASK [ocp-customization : Insure able to fetch project list] *******************
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (60 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (59 retries left).
module.install.null_resource.install: Still creating... [32m1s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (58 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (57 retries left).
module.install.null_resource.install: Still creating... [32m11s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (56 retries left).
module.install.null_resource.install: Still creating... [32m21s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (55 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (54 retries left).
module.install.null_resource.install: Still creating... [32m31s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (53 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (52 retries left).
module.install.null_resource.install: Still creating... [32m41s elapsed]
module.install.null_resource.install: Still creating... [32m51s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (51 retries left).
module.install.null_resource.install: Still creating... [33m1s elapsed]
module.install.null_resource.install: Still creating... [33m11s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (50 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (49 retries left).
module.install.null_resource.install: Still creating... [33m21s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (48 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (47 retries left).
module.install.null_resource.install: Still creating... [33m31s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (46 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (45 retries left).
module.install.null_resource.install: Still creating... [33m41s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (44 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (43 retries left).
module.install.null_resource.install: Still creating... [33m51s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (42 retries left).
module.install.null_resource.install: Still creating... [34m1s elapsed]
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (41 retries left).
module.install.null_resource.install (remote-exec): FAILED - RETRYING: Insure able to fetch project list (40 retries left).
module.install.null_resource.install: Still creating... [34m11s elapsed]
module.install.null_resource.install (remote-exec): changed: [cecc-11579-bastion-0] => {"attempts": 22, "changed": true, "cmd": "oc get projects", "delta": "0:00:00.180335", "end": "2022-04-28 16:38:33
.728808", "rc": 0, "start": "2022-04-28 16:38:33.548473", "stderr": "", "stderr_lines": [], "stdout": "NAME                                               DISPLAY NAME   STATUS\ndefault                       

<snip>

module.install.null_resource.install (remote-exec): TASK [ocp-customization : Create powervm-rmc project] **************************
module.install.null_resource.install (remote-exec): changed: [cecc-11579-bastion-0] => {"changed": true, "method": "create", "result": {"apiVersion": "project.openshift.io/v1", "kind": "Project", "meta
data": {"annotations": {"openshift.io/display-name": ""}, "creationTimestamp": "2022-04-28T20:38:34Z", "labels": {"kubernetes.io/metadata.name": "powervm-rmc"}, "managedFields": [{"apiVersion": "v1", "fields
Type": "FieldsV1", "fieldsV1": {"f:metadata": {"f:annotations": {".": {}, "f:openshift.io/display-name": {}}, "f:labels": {".": {}, "f:kubernetes.io/metadata.name": {}}}, "f:spec": {"f:finalizers": {}}}, "ma
nager": "Go-http-client", "operation": "Update", "time": "2022-04-28T20:38:34Z"}], "name": "powervm-rmc", "resourceVersion": "19379", "uid": "820b894e-c400-4b59-b805-4c758ac99bf3"}, "spec": {"finalizers": ["
openshift.io/origin", "kubernetes"]}, "status": {"phase": "Active"}}}
