### PR TITLE
Changes for enabling Luks encryption on all OCP cluster nodes

### DIFF
--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -56,6 +56,16 @@
     args:
       chdir: "{{ workdir }}"
 
+#  - name: Generate Machine Config Master
+#    template:
+#      src: ../templates/99-master-machineconfig.yaml.j2
+#      dest: "{{ workdir }}/openshift/99-master-machineconfig.yaml"
+
+#  - name: Generate Machine Config Worker
+#    template:
+#      src: ../templates/99-worker-machineconfig.yaml.j2
+#      dest: "{{ workdir }}/openshift/99-worker-machineconfig.yaml"
+
   - name: Setup network configuration
     template:
       src: ../templates/cluster-network-03-config.yml.j2

--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -56,15 +56,15 @@
     args:
       chdir: "{{ workdir }}"
 
-#  - name: Generate Machine Config Master
-#    template:
-#      src: ../templates/99-master-machineconfig.yaml.j2
-#      dest: "{{ workdir }}/openshift/99-master-machineconfig.yaml"
+  - name: Generate Machine Config Master
+    template:
+      src: ../templates/99-master-machineconfig.yaml.j2
+      dest: "{{ workdir }}/openshift/99-master-machineconfig.yaml"
 
-#  - name: Generate Machine Config Worker
-#    template:
-#      src: ../templates/99-worker-machineconfig.yaml.j2
-#      dest: "{{ workdir }}/openshift/99-worker-machineconfig.yaml"
+  - name: Generate Machine Config Worker
+    template:
+      src: ../templates/99-worker-machineconfig.yaml.j2
+      dest: "{{ workdir }}/openshift/99-worker-machineconfig.yaml"
 
   - name: Setup network configuration
     template:

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -17,12 +17,12 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: hgyZt_hjtRWR5dLJEMI2_oWhlXE
-                url: http://192.168.100.25:80	
-              - thumbprint: FRMRTBHPHSfTIEEHuM_bVvh6EgM
-                url: http://192.168.100.207:80
-              - thumbprint: CC0u3kMJA2YrmusxqlKsIksin3A
-                url: http://192.168.100.181:80	
+              - thumbprint: bQ-IhgJhF57Z_aFDymu0Hhtb_iI
+                url: http://192.168.0.175:80	
+              - thumbprint: UAk5LlyqBANqGWQeRwOUfHkLcFA
+                url: http://192.168.0.220:80
+              - thumbprint: Sa4_90rsXMXVtgjcULwOQv9QnG0
+                url: http://192.168.0.210:80	
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -27,4 +27,3 @@ spec:
             - --cipher
             - aes-cbc-essiv:sha256
           wipeVolume: true 
-  fips: true

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -17,8 +17,8 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: FQaIOvjdK2ZO7T4VbmIYZTy8l5g
-                url: http://192.168.12.107:80
+              - thumbprint: dfIXBh5AOkuFn81zbz9EafYIzSc
+                url: http://192.168.0.110:80
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -17,8 +17,8 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: {{ thumbprint }}
-                url: {{ tang_server_ip:port }}
+              - thumbprint: a3g3EE0MKttkjtBqzNghHCAZhsw
+                url: http://193.168.200.146:80
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -17,8 +17,12 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: dfIXBh5AOkuFn81zbz9EafYIzSc
-                url: http://192.168.0.110:80
+              - thumbprint: FRDoRSaRJUknVY01ToPu-DSWVC0
+                url: http://192.168.100.210:80	
+              - thumbprint: 8oLBQpl4R94HQRyVL5xhB-KQ9aM
+                url: http://192.168.100.20:80
+              - thumbprint: 8kQLnd23vDK5GYOcAU8UsR9AIOo
+                url: http://192.168.100.73:80	
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root
@@ -28,4 +32,5 @@ spec:
             - aes-cbc-essiv:sha256
           wipeVolume: true
   fips: true
+
 

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -1,0 +1,30 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: master-storage
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          label: root
+          wipeFilesystem: true
+      luks:
+        - clevis:
+            tang:
+              - thumbprint: {{ thumbprint }}
+                url: {{ tang_server_ip:port }}
+            threshold: 1
+          device: /dev/disk/by-partlabel/root
+          label: luks-root
+          name: root
+          options:
+            - --cipher
+            - aes-cbc-essiv:sha256
+          wipeVolume: true 
+  fips: true

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -17,12 +17,12 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: FRDoRSaRJUknVY01ToPu-DSWVC0
-                url: http://192.168.100.210:80	
-              - thumbprint: 8oLBQpl4R94HQRyVL5xhB-KQ9aM
-                url: http://192.168.100.20:80
-              - thumbprint: 8kQLnd23vDK5GYOcAU8UsR9AIOo
-                url: http://192.168.100.73:80	
+              - thumbprint: hgyZt_hjtRWR5dLJEMI2_oWhlXE
+                url: http://192.168.100.25:80	
+              - thumbprint: FRMRTBHPHSfTIEEHuM_bVvh6EgM
+                url: http://192.168.100.207:80
+              - thumbprint: CC0u3kMJA2YrmusxqlKsIksin3A
+                url: http://192.168.100.181:80	
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -26,4 +26,6 @@ spec:
           options:
             - --cipher
             - aes-cbc-essiv:sha256
-          wipeVolume: true 
+          wipeVolume: true
+  fips: true
+

--- a/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-master-machineconfig.yaml.j2
@@ -17,8 +17,8 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: a3g3EE0MKttkjtBqzNghHCAZhsw
-                url: http://193.168.200.146:80
+              - thumbprint: FQaIOvjdK2ZO7T4VbmIYZTy8l5g
+                url: http://192.168.12.107:80
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -27,4 +27,5 @@ spec:
             - --cipher
             - aes-cbc-essiv:sha256
           wipeVolume: true 
+  fips: true
 

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -2,8 +2,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
-  name: worker-storage
+    machineconfiguration.openshift.io/role: master
+  name: master-storage
 spec:
   config:
     ignition:
@@ -17,8 +17,12 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: dfIXBh5AOkuFn81zbz9EafYIzSc
-                url: http://192.168.0.110:80
+              - thumbprint: FRDoRSaRJUknVY01ToPu-DSWVC0
+                url: http://192.168.100.210:80	
+              - thumbprint: 8oLBQpl4R94HQRyVL5xhB-KQ9aM
+                url: http://192.168.100.20:80
+              - thumbprint: 8kQLnd23vDK5GYOcAU8UsR9AIOo
+                url: http://192.168.100.73:80	
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root
@@ -26,6 +30,7 @@ spec:
           options:
             - --cipher
             - aes-cbc-essiv:sha256
-          wipeVolume: true 
+          wipeVolume: true
   fips: true
+
 

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -1,0 +1,31 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: worker-storage
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          label: root
+          wipeFilesystem: true
+      luks:
+        - clevis:
+            tang:
+              - thumbprint: {{ thumbprint }}
+                url: {{ tang_server_ip:port }}
+            threshold: 1
+          device: /dev/disk/by-partlabel/root
+          label: luks-root
+          name: root
+          options:
+            - --cipher
+            - aes-cbc-essiv:sha256
+          wipeVolume: true 
+  fips: true
+

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -2,8 +2,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master
-  name: master-storage
+    machineconfiguration.openshift.io/role: worker
+  name: worker-storage
 spec:
   config:
     ignition:
@@ -22,7 +22,7 @@ spec:
               - thumbprint: 8oLBQpl4R94HQRyVL5xhB-KQ9aM
                 url: http://192.168.100.20:80
               - thumbprint: 8kQLnd23vDK5GYOcAU8UsR9AIOo
-                url: http://192.168.100.73:80	
+                url: http://192.168.100.73:80				
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root
@@ -30,7 +30,6 @@ spec:
           options:
             - --cipher
             - aes-cbc-essiv:sha256
-          wipeVolume: true
+          wipeVolume: true 
   fips: true
-
 

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -17,8 +17,8 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: FQaIOvjdK2ZO7T4VbmIYZTy8l5g
-                url: http://192.168.12.107:80
+              - thumbprint: dfIXBh5AOkuFn81zbz9EafYIzSc
+                url: http://192.168.0.110:80
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -17,8 +17,8 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: {{ thumbprint }}
-                url: {{ tang_server_ip:port }}
+              - thumbprint: a3g3EE0MKttkjtBqzNghHCAZhsw
+                url: http://193.168.200.146:80
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -17,12 +17,12 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: hgyZt_hjtRWR5dLJEMI2_oWhlXE
-                url: http://192.168.100.25:80	
-              - thumbprint: FRMRTBHPHSfTIEEHuM_bVvh6EgM
-                url: http://192.168.100.207:80
-              - thumbprint: CC0u3kMJA2YrmusxqlKsIksin3A
-                url: http://192.168.100.181:80				
+              - thumbprint: bQ-IhgJhF57Z_aFDymu0Hhtb_iI
+                url: http://192.168.0.175:80	
+              - thumbprint: UAk5LlyqBANqGWQeRwOUfHkLcFA
+                url: http://192.168.0.220:80
+              - thumbprint: Sa4_90rsXMXVtgjcULwOQv9QnG0
+                url: http://192.168.0.210:80		
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -17,12 +17,12 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: FRDoRSaRJUknVY01ToPu-DSWVC0
-                url: http://192.168.100.210:80	
-              - thumbprint: 8oLBQpl4R94HQRyVL5xhB-KQ9aM
-                url: http://192.168.100.20:80
-              - thumbprint: 8kQLnd23vDK5GYOcAU8UsR9AIOo
-                url: http://192.168.100.73:80				
+              - thumbprint: hgyZt_hjtRWR5dLJEMI2_oWhlXE
+                url: http://192.168.100.25:80	
+              - thumbprint: FRMRTBHPHSfTIEEHuM_bVvh6EgM
+                url: http://192.168.100.207:80
+              - thumbprint: CC0u3kMJA2YrmusxqlKsIksin3A
+                url: http://192.168.100.181:80				
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -27,5 +27,4 @@ spec:
             - --cipher
             - aes-cbc-essiv:sha256
           wipeVolume: true 
-  fips: true
 

--- a/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-worker-machineconfig.yaml.j2
@@ -17,8 +17,8 @@ spec:
       luks:
         - clevis:
             tang:
-              - thumbprint: a3g3EE0MKttkjtBqzNghHCAZhsw
-                url: http://193.168.200.146:80
+              - thumbprint: FQaIOvjdK2ZO7T4VbmIYZTy8l5g
+                url: http://192.168.12.107:80
             threshold: 1
           device: /dev/disk/by-partlabel/root
           label: luks-root


### PR DESCRIPTION
Signed-off-by: Aditi Jadhav <aditijadhav38@gmail.com>
Signed-off-by: Gaurav Bankar <gauravpbankar@gmail.com>


Description:
As part of security work we need to enable LUKS encryption for OCP cluster nodes.
Thus updated required changes verified on local OCP cluster.