### PR TITLE
installs oauthlib=3.2.0 python pkg

### DIFF
--- a/playbooks/roles/ocp-customization/tasks/main.yaml
+++ b/playbooks/roles/ocp-customization/tasks/main.yaml
@@ -9,6 +9,12 @@
       - gcc
     state: present
 
+- name: Install python packages
+  become: true
+  pip:
+    executable: pip3
+    name: oauthlib==3.2.0
+
 - name: Install openshift python module
   become: true
   pip:


### PR DESCRIPTION
To fix ImportError for SIGNATURE_RSA from oauthlib.oauth1 (python module) observed while working with centos9-stream. This issue was observed in both master and worker nodes