### PR TITLE
Add support for LUKS encryption for OCP4

### DIFF
--- a/playbooks/roles/ocp-config/README.md
+++ b/playbooks/roles/ocp-config/README.md
@@ -11,32 +11,51 @@ Requirements
  - Updated pull secret file with registry credentials located at `~/.openshift/pull-secret-updated` (Required for restricted network install)
  - Registry certificate file located at `/opt/registry/certs/domain.crt` (Required for restricted network install)
  - Local registry with local repo named as `ocp4/openshift4` (Required for restricted network install)
+ 
+Luks Encryption Setup using Tang Server
+---------------------------------------
+
+**_Note: This is Day-1 Activity for encryption._**
+This feature will enable Luks Encryption using Tang Server on all master/worker nodes. 
+Added seperate MachineConfiguration file for master and worker which will perform LUKS encryption.
 
 Role Variables
 --------------
 
-| Variable                    | Required | Default        | Comments                                    |
-|-----------------------------|----------|----------------|---------------------------------------------|
-| workdir                     | no       | ~/ocp4-workdir | Place for config generation and auth files  |
-| log_level                   | no       | info           | Option --log-level in openshift-install cmd |
-| release_image_override      | no       | ""             | OCP image overide variable                  |
-| master_count                | yes      |                | Number of master nodes                      |
-| worker_count                | yes      |                | Number of worker nodes                      |
-| setup_squid_proxy           | no       | false          | Flag for setting up squid proxy server on bastion node |
-| proxy_url                   | no       | ""             | Proxy url eg: http://[user:passwd@]server:port (NA when setup_squid_proxy: true)|
-| no_proxy                    | no       | ""             | Comma seperated string of domains/cidr to exclude proxy |
-| enable_local_registry       | no       | false          | Set to true to enable usage of local registry for restricted network install |
-| fips_compliant              | no       | false          | Set to true to enable usage of FIPS for OCP deployment |
-| chronyconfig.enabled        | no       | true           | Set to true to enable chrony configuration on the bastion node during installation. This also configure the bastion as a NTP server for the cluster. |
-| chronyconfig.content        | no       | ""             | List of time NTP servers and options pair (see chronyconfig examples). If empty, bastion will try sync with some default ntp server (internet) AND local HW clock (with higher stratum). |
-| chronyconfig.allow          | no       | ""             | List of network cidr (X.X.X.X/Y) allowed to sync with bastion configured as NTP server |
-| dhcp_shared_network         | no       |                | Flag to update DHCP server work on a shared network. (Neither ACK nor NACK unknown clients) |
-| cni_network_provider        | no       | OVNKubernetes  | Sets the default Container Network Interface (CNI) network provider for the cluster |
-| cni_network_mtu             | no       |                | MTU value to assign to the CNI network. Recommended values for OpenshiftSDN: <NIC MTU> - 50; OVNKubernetes: <NIC MTU> - 100 |
-| cluster_network_cidr        | no       | 10.128.0.0/14  | Network (in CIDR) used for the pod networks.
-| cluster_network_hostprefix  | no       | 23             | The subnet prefix length to assign to each individual node. (netmask in CIDR format)
-| service_network             | no       | 172.30.0.0/16  | Network (in CIDR) used for the service network.
-| rhcos_pre_kernel_options    | no       | []             | List of day-1 kernel options for RHCOS nodes eg: ["rd.multipath=default","root=/dev/disk/by-label/dm-mpath-root"] |
+| Variable                    | Required | Default                               | Comments                                    |
+|-----------------------------|----------|---------------------------------------|---------------------------------------------|
+| workdir                     | no       | ~/ocp4-workdir                        | Place for config generation and auth files  |
+| log_level                   | no       | info                                  | Option --log-level in openshift-install cmd |
+| release_image_override      | no       | ""                                    | OCP image overide variable                  |
+| master_count                | yes      |                                       | Number of master nodes                      |
+| worker_count                | yes      |                                       | Number of worker nodes                      |
+| setup_squid_proxy           | no       | false                                 | Flag for setting up squid proxy server on bastion node |
+| proxy_url                   | no       | ""                                    | Proxy url eg: http://[user:passwd@]server:port (NA when setup_squid_proxy: true)|
+| no_proxy                    | no       | ""                                    | Comma seperated string of domains/cidr to exclude proxy |
+| enable_local_registry       | no       | false                                 | Set to true to enable usage of local registry for restricted network install |
+| fips_compliant              | no       | false                                 | Set to true to enable usage of FIPS for OCP deployment |
+| chronyconfig.enabled        | no       | true                                  | Set to true to enable chrony configuration on the bastion node during installation. This also configure the bastion as a NTP server for the cluster. |
+| chronyconfig.content        | no       | ""                                    | List of time NTP servers and options pair (see chronyconfig examples). If empty, bastion will try sync with some default ntp server (internet) AND local HW clock (with higher stratum). |
+| chronyconfig.allow          | no       | ""                                    | List of network cidr (X.X.X.X/Y) allowed to sync with bastion configured as NTP server |
+| dhcp_shared_network         | no       |                                       | Flag to update DHCP server work on a shared network. (Neither ACK nor NACK unknown clients) |
+| cni_network_provider        | no       | OVNKubernetes                         | Sets the default Container Network Interface (CNI) network provider for the cluster |
+| cni_network_mtu             | no       |                                       | MTU value to assign to the CNI network. Recommended values for OpenshiftSDN: <NIC MTU> - 50; OVNKubernetes: <NIC MTU> - 100 |
+| cluster_network_cidr        | no       | 10.128.0.0/14                         | Network (in CIDR) used for the pod networks.
+| cluster_network_hostprefix  | no       | 23                                    | The subnet prefix length to assign to each individual node. (netmask in CIDR format)
+| service_network             | no       | 172.30.0.0/16                         | Network (in CIDR) used for the service network.
+| rhcos_pre_kernel_options    | no       | []                                    | List of day-1 kernel options for RHCOS nodes eg: ["rd.multipath=default","root=/dev/disk/by-label/dm-mpath-root"] |
+| luks.enabled                | no       | false                                 | Set it true if you prefer to enable LUKS in OCP deployment |
+| luks.config                 | yes      |                                       | List of tang servers and thumbprint to apply |
+| luks.config[].thumbprint    | yes      |                                       | Thumbprint of tang server to be added in luks_config |
+| luks.config[].url           | yes      |                                       | URL of tang server to be added in luks_config |
+| luks.filesystem_device      | no       | /dev/mapper/root                      | Set the Path of device to be luks encrypted |
+| luks.format                 | no       | xfs                                   | Set the Format of the FileSystem to be luks encrypted |
+| luks.wipeFileSystem         | no       | true                                  | Configures the FileSystem to be wiped |
+| luks.device                 | no       | /dev/disk/by-partlabel/root           | Set the Path of luks encrypted partition |
+| luks.label                  | no       | luks-root                             | Set the value for user label of luks encrpted partition |
+| luks.options                | no       | ["--cipher", "aes-cbc-essiv:sha256"]  | Set List of luks options for the luks encryption |
+| luks.wipeVolume             | no       | true                                  | Configures the luks encrypted partition to be wiped |
+| luks.name                   | no       | root                                  | Set the value for the user label of Filesystem to be luks encrypted |
 
 *chronyconfig variable example *
 
@@ -51,6 +70,25 @@ chronyconfig:
     allow:
       - 10.1.1.1/24
       - 10.1.2.3/16
+```
+
+*Ansible variable for Luks Encryption example*
+```
+luks:
+ enabled: true
+ config:
+    - thumbprint: *********
+      url: http://*.*.*.*:*
+ filesystem_device: /dev/mapper/root
+ format: xfs
+ wipeFileSystem: true
+ device: /dev/disk/by-partlabel/root
+ label: luks-root
+ options:
+    - --cipher
+    - aes-cbc-essiv:sha256
+ wipeVolume: true
+ name: root
 ```
 
 Dependencies

--- a/playbooks/roles/ocp-config/defaults/main/main.yaml
+++ b/playbooks/roles/ocp-config/defaults/main/main.yaml
@@ -18,3 +18,15 @@ cluster_network_cidr: 10.128.0.0/14
 cluster_network_hostprefix: 23
 service_network: 172.30.0.0/16
 fips_compliant: false
+luks:
+   enabled: false
+   filesystem_device: /dev/mapper/root
+   format: xfs
+   wipeFileSystem: true
+   device: /dev/disk/by-partlabel/root
+   label: luks-root
+   options:
+      - --cipher
+      - aes-cbc-essiv:sha256
+   wipeVolume: true
+   name: root

--- a/playbooks/roles/ocp-config/tasks/machineconfig_luks.yaml
+++ b/playbooks/roles/ocp-config/tasks/machineconfig_luks.yaml
@@ -1,0 +1,9 @@
+- name: Create Machine Config
+  vars:
+    role_n: '{{ item }}'
+  template:
+    src: ../templates/99-node-machineconfig.yaml.j2
+    dest: "{{ workdir }}/openshift/99-{{ item }}-machineconfig.yaml"
+  with_items:
+    - master
+    - worker

--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -56,6 +56,14 @@
     args:
       chdir: "{{ workdir }}"
 
+  - name: Generate Machine Config Master and Worker nodes
+    when:
+      - luks is defined and luks.enabled
+      - luks.config | length > 0
+      - luks.config[0].thumbprint is not none
+      - luks.config[0].url is not none
+    import_tasks: machineconfig_luks.yaml
+
   - name: Setup network configuration
     template:
       src: ../templates/cluster-network-03-config.yml.j2

--- a/playbooks/roles/ocp-config/templates/99-node-machineconfig.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/99-node-machineconfig.yaml.j2
@@ -1,0 +1,34 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: '{{ role_n }}'
+  name: '99-{{ role_n }}-storage-encryption'
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      filesystems:
+        - device: {{ luks.filesystem_device }}
+          format: {{ luks.format }}
+          label: {{ luks.name }}
+          wipeFilesystem: {{ luks.wipeFileSystem }}
+      luks:
+        - clevis:
+            tang:
+{% for item in luks.config  %}
+{% if item.thumbprint is not none and item.url is not none %}
+              - thumbprint: {{ item.thumbprint}}
+                url: {{ item.url }}
+{% endif %}
+{% endfor %}
+            threshold: 1
+          device: {{ luks.device }}
+          label: {{ luks.label }}
+          name: {{ luks.name }}
+          options:
+{% for item in luks.options %}
+            - {{ item }}
+{% endfor %}
+          wipeVolume: {{ luks.wipeVolume }}


### PR DESCRIPTION
This PR is mainly related to LUKS encryption which is required for PCI profile compliance.
To achieve this we have followed below document
https://docs.openshift.com/container-platform/4.11/installing/install_config/installing-customizing.html

This PR contains the variable and tasks that are required for encrypting block device in LUKS2 format.
This feature will enable Luks Encryption using Tang Server on all master/worker nodes. 
Added separate MachineConfiguration template files for masters and workers which will perform LUKS encryption.

**Note: This is Day-1 activity. By default the encryption is disabled. User need to enable it in var.tfvars file during OCP deployment.**
For more details please refer PR https://github.com/ocp-power-automation/ocp4-upi-powervs/pull/441

Signed-off-by: Aditi Jadhav <aditi.jadhav1@ibm.com>