### PR TITLE
Update the memory limits for the `powervm-rmc` pods.

### DIFF
--- a/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
+++ b/playbooks/roles/ocp-customization/tasks/powervm_rmc.yaml
@@ -68,7 +68,7 @@
                     cpu: 100m
                     memory: 500Mi
                   limits:
-                    memory: 1Gi
+                    memory: 4Gi
                 volumeMounts:
                   - name: lib-modules
                     mountPath: /lib/modules


### PR DESCRIPTION
This PR has the updated limits for the `powervm-rmc` pod which prevents encountering the `OOMKilled` and subsequent `CrashLoopBackOff` errors on large compute nodes for the same. 

The change was tested on a node of size 64 Cores and 256GB of memory and the desired behaviour of the `powervm-rmc` pod was observed.