### PR TITLE
force chronyd start on helper before cert generation

### DIFF
--- a/playbooks/roles/ocp-config/tasks/chrony.yaml
+++ b/playbooks/roles/ocp-config/tasks/chrony.yaml
@@ -76,3 +76,9 @@
     dest: /etc/systemd/system/chronyd.service.d/restart.conf
   notify:
     - restart chrony
+
+- name: Force Chronyd Restart
+  systemd:
+    name: chronyd
+    daemon_reload: true
+    state: restarted


### PR DESCRIPTION
Manually restart chronyd and not wait for trigger to be sure that time is right before creating openshift certificates.
