### PR TITLE
Remove mechanism to check ssh connection to worker

### DIFF
--- a/playbooks/install-complete.yaml
+++ b/playbooks/install-complete.yaml
@@ -1,15 +1,6 @@
 ---
 # file: install-complete.yml
 
-- name: Check and configure compute nodes
-  hosts: workers
-  gather_facts: no
-  any_errors_fatal: true
-  serial:
-  - 1
-  roles:
-  - nodes-config
-
 - name: Install and Customize OCP
   hosts: bastion[0]
   roles:


### PR DESCRIPTION
This PR removes the call to the **nodes-config**  role, which checks the ssh connection to the worker.