### PR TITLE
Updating the correct file format from yaml to json

### DIFF
--- a/playbooks/roles/ocp-upgrade/tasks/restricted_network_upgrade.yaml
+++ b/playbooks/roles/ocp-upgrade/tasks/restricted_network_upgrade.yaml
@@ -41,7 +41,7 @@
 
 - name: Apply mirrored release image signature config
   shell: |
-    oc apply -f {{ repo_image_dir }}/mirror/config/signature-sha256-{{ upgrade_image_sha_key.stdout[:16] }}.yaml
+    oc apply -f {{ repo_image_dir }}/mirror/config/signature-sha256-{{ upgrade_image_sha_key.stdout[:16] }}.json
 
 - name: Get the OCP version 
   kubernetes.core.k8s_info:


### PR DESCRIPTION
The existing automation was failing with below error -
```
TASK [ocp-upgrade : Apply mirrored release image signature config] ******************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "oc apply -f /root/ocp_repo_image/mirror/config/signature-sha256-ad24cfa417d60902.yaml\n", "delta": "0:00:01.940379", "end": "2023-07-17 03:48:22.698712", "msg": "non-zero return code", "rc": 1, "start": "2023-07-17 03:48:20.758333", "stderr": "error: the path \"/root/ocp_repo_image/mirror/config/signature-sha256-ad24cfa417d60902.yaml\" does not exist", "stderr_lines": ["error: the path \"/root/ocp_repo_image/mirror/config/signature-sha256-ad24cfa417d60902.yaml\" does not exist"], "stdout": "", "stdout_lines": []}
```

Because the script is looking for `.yaml` file and the file is getting created with `.json` format.

Fixing the automation by updating the correct file format.