### PR TITLE
Curl to get latest version even if pre-release

### DIFF
--- a/playbooks/roles/ocp-customization/tasks/powervm_rsct.yaml
+++ b/playbooks/roles/ocp-customization/tasks/powervm_rsct.yaml
@@ -7,7 +7,7 @@
 
 - name: Get latest RSCT Operator version
   shell: |
-    curl -s "https://api.github.com/repos/ocp-power-automation/rsct-operator/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -s "https://api.github.com/repos/ocp-power-automation/rsct-operator/releases" | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
   register: rsct_version
   changed_when: false
 


### PR DESCRIPTION
-Recently, all of RSCT Operator version including the latest was marked as pre-release 
-Fixing the curl URL to help get the right version 
-Refer - https://github.com/ocp-power-automation/rsct-operator/releases 