### PR TITLE
OpenShiftP-633: Use oc-mirror --v2 in disconnected installations

### DIFF
--- a/examples/install_vars.yaml
+++ b/examples/install_vars.yaml
@@ -13,6 +13,8 @@ release_image_override: ""
 # IBM/Red Hat QE Only: Disables ClusterImagePolicy so Nightly builds can be deployed. This feature puts a cluster in unsupported mode.
 qe_only_disable_image_policy: false
 
+qe_only_release_override: false
+
 node_connection_timeout: 2700
 
 rhcos_pre_kernel_options: []

--- a/playbooks/roles/ocp-config/defaults/main/main.yaml
+++ b/playbooks/roles/ocp-config/defaults/main/main.yaml
@@ -8,6 +8,7 @@ release_image_override: ""
 
 # IBM/Red Hat QE Only: Disables ClusterImagePolicy so Nightly builds can be deployed. This feature puts a cluster in unsupported mode.
 qe_only_disable_image_policy: false
+qe_only_release_override: false
 proxy_url: ""
 no_proxy: ""
 enable_local_registry: false

--- a/playbooks/roles/ocp-config/tasks/extract.yaml
+++ b/playbooks/roles/ocp-config/tasks/extract.yaml
@@ -24,10 +24,62 @@
       timeout: 15
   when: enable_local_registry
 
-- name: Extract OCP4 tools from release image ( local-registry )
-  when: enable_local_registry
+- name: Check if oc-mirror is already installed
+  command: which oc-mirror
+  register: oc_mirror_check
+  failed_when: false
+  changed_when: false
+
+- name: Check if release_image_override is digest image
+  set_fact:
+    is_digest_image: "{{ '@sha256:' in release_image_override }}"
+  when: enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Split release_image_override image into base and tag(for image with digest value)
+  set_fact:
+    base_image: "{{ release_image_override.split('@')[0] }}"
+    image_tag: "{{ release_image_override.split('@')[1] }}"
+  when: is_digest_image and enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Split release_image_override image into base and tag(for image with release tag)
+  set_fact:
+    base_image: "{{ release_image_override.rsplit(':', 1)[0] }}"
+    image_tag: "{{ release_image_override.rsplit(':', 1)[1] }}"
+  when: not is_digest_image and enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Ensure base_image ends with /openshift/release-images
+  set_fact:
+    base_image: >-
+      {{ base_image if base_image.endswith('/openshift/release-images')
+         else base_image ~ '/openshift/release-images' }}
+  when: enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Build new_release_image_override(local-registry and oc-mirror and tag based release image )
+  set_fact:
+    new_release_image_override: "{{ base_image }}:{{ image_tag }}"
+  when: not is_digest_image and enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Build new_release_image_override(local-registry and oc-mirror and digest based image)
+  set_fact:
+    new_release_image_override: "{{ base_image }}@{{ image_tag }}"
+  when: is_digest_image and enable_local_registry and oc_mirror_check.rc == 0
+
+- name : Build the release_image_override (local-registry and oc-mirror and digest based image)
+  set_fact:
+    release_image_override: "{{ base_image }}@{{ image_tag }}"
+  when: enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Update new_release_image_override value in install_vars.yaml
+  ansible.builtin.replace:
+    path: /root/ocp4-playbooks/install_vars.yaml
+    regexp: 'release_image_override:\s*.*'
+    replace: "release_image_override: {{ new_release_image_override }}"
+  when: enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Extract OCP4 tools from release image ( local-registry and oc-mirror )
+  when: enable_local_registry and oc_mirror_check.rc == 0
   shell: |
-    oc adm release extract --tools {{ release_image_override }} --registry-config='{{ ansible_env.HOME }}/.openshift/pull-secret-updated'
+    oc adm release extract --tools {{ new_release_image_override }} --registry-config='{{ ansible_env.HOME }}/.openshift/pull-secret-updated'
   args:
     chdir: "{{ tools_dir }}"
 

--- a/playbooks/roles/ocp-config/tasks/extract.yaml
+++ b/playbooks/roles/ocp-config/tasks/extract.yaml
@@ -24,10 +24,62 @@
       timeout: 15
   when: enable_local_registry
 
-- name: Extract OCP4 tools from release image ( local-registry )
-  when: enable_local_registry
+- name: Check if oc-mirror is already installed
+  command: which oc-mirror
+  register: oc_mirror_check
+  failed_when: false
+  changed_when: false
+
+- name: Check if release_image_override is digest image
+  set_fact:
+    is_digest_image: "{{ '@sha256:' in release_image_override }}"
+  when: enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Split release_image_override image into base and tag(for image with digest value)
+  set_fact:
+    base_image: "{{ release_image_override.split('@')[0] }}"
+    image_tag: "{{ release_image_override.split('@')[1] }}"
+  when: is_digest_image and enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Split release_image_override image into base and tag(for image with release tag)
+  set_fact:
+    base_image: "{{ release_image_override.rsplit(':', 1)[0] }}"
+    image_tag: "{{ release_image_override.rsplit(':', 1)[1] }}"
+  when: not is_digest_image and enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Ensure base_image ends with /openshift/release-images
+  set_fact:
+    base_image: >-
+      {{ base_image if base_image.endswith('/openshift/release-images')
+         else base_image ~ '/openshift/release-images' }}
+  when: enable_local_registry and oc_mirror_check.rc == 0
+
+- name: Build new_release_image_override(local-registry and oc-mirror and tag based release image )
+  set_fact:
+    new_release_image_override: "{{ base_image }}:{{ image_tag }}"
+  when: not is_digest_image and enable_local_registry and oc_mirror_check.rc == 0 and qe_only_release_override
+
+- name: Build new_release_image_override(local-registry and oc-mirror and digest based image)
+  set_fact:
+    new_release_image_override: "{{ base_image }}@{{ image_tag }}"
+  when: is_digest_image and enable_local_registry and oc_mirror_check.rc == 0 and qe_only_release_override
+
+- name : Build the release_image_override (local-registry and oc-mirror and digest based image)
+  set_fact:
+    release_image_override: "{{ base_image }}@{{ image_tag }}"
+  when: enable_local_registry and oc_mirror_check.rc == 0 and qe_only_release_override
+
+- name: Update new_release_image_override value in install_vars.yaml
+  ansible.builtin.replace:
+    path: /root/ocp4-playbooks/install_vars.yaml
+    regexp: 'release_image_override:\s*.*'
+    replace: "release_image_override: {{ new_release_image_override }}"
+  when: enable_local_registry and oc_mirror_check.rc == 0 and qe_only_release_override
+
+- name: Extract OCP4 tools from release image ( local-registry and oc-mirror )
+  when: enable_local_registry and oc_mirror_check.rc == 0 and qe_only_release_override
   shell: |
-    oc adm release extract --tools {{ release_image_override }} --registry-config='{{ ansible_env.HOME }}/.openshift/pull-secret-updated'
+    oc adm release extract --tools {{ new_release_image_override }} --registry-config='{{ ansible_env.HOME }}/.openshift/pull-secret-updated'
   args:
     chdir: "{{ tools_dir }}"
 
@@ -62,6 +114,11 @@
     path: "/usr/local/bin/openshift-install"
   register: binary_check
   
+- name: Check if openshift-install-fips binary exists
+  ansible.builtin.stat:
+    path: "/usr/local/bin/openshift-install-fips"
+  register: fips_binary_check
+
 - name: Remove openshift-install binary when FIPS is enabled
   ansible.builtin.file:
     path: "/usr/local/bin/openshift-install"
@@ -77,7 +134,7 @@
     state: link
   when: 
     - fips_compliant  # FIPS is enabled
-    - binary_check.stat.exists
+    - fips_binary_check.stat.exists
 
 - name: Remove tools directory
   file:

--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -99,6 +99,37 @@
       - "/machineconfig/*-chrony-configuration.yaml"
     when: chronyconfig.enabled
 
+  - name: Check if oc-mirror is already installed
+    command: which oc-mirror
+    register: oc_mirror_check
+    failed_when: false
+    changed_when: false
+
+  - name: Build new_release_image_override from existing release_image_override(Without local-registry, oc-mirror )
+    set_fact:
+      new_release_image_override: "{{ release_image_override }}"
+    when:
+      - not ( qe_only_release_override | default(false) | bool )
+      - not ( enable_local_registry | default(false) | bool )
+
+  - name: Split release_image_override image into base and tag(for image with release tag)
+    set_fact:
+      base_image: "{{ release_image_override.rsplit(':', 1)[0] }}"
+      image_tag: "{{ release_image_override.rsplit(':', 1)[1] }}"
+    when: qe_only_release_override and enable_local_registry and oc_mirror_check.rc == 0
+
+  - name: Ensure base_image ends with /openshift/release-images
+    set_fact:
+      base_image: >-
+        {{ base_image if base_image.endswith('/openshift/release-images')
+          else base_image ~ '/openshift/release-images' }}
+    when: qe_only_release_override and enable_local_registry and oc_mirror_check.rc == 0
+
+  - name: Build new_release_image_override(local-registry and oc-mirror and tag based release image )
+    set_fact:
+      new_release_image_override: "{{ base_image }}:{{ image_tag }}"
+    when: qe_only_release_override and enable_local_registry and oc_mirror_check.rc == 0
+
   - name: Generate kdump machine configuration
     vars:
       kdump_sysconfig: |
@@ -120,7 +151,7 @@
     when: kdump.enabled
 
   - name: Create ignition files
-    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
+    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ new_release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"
 

--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -19,6 +19,13 @@
   import_tasks: chrony.yaml
   when: chronyconfig.enabled
 
+- name: Build new_release_image_override from existing release_image_override(local-registry, without qe_only_release_override)
+  set_fact:
+    new_release_image_override: "{{ release_image_override }}"
+  when:
+    - not ( qe_only_release_override | default(false) | bool )
+    - enable_local_registry | default(false) | bool
+
 - name: OCP config
   when: inventory_hostname in groups['bastion'][0]
   block:
@@ -99,6 +106,37 @@
       - "/machineconfig/*-chrony-configuration.yaml"
     when: chronyconfig.enabled
 
+  - name: Check if oc-mirror is already installed
+    command: which oc-mirror
+    register: oc_mirror_check
+    failed_when: false
+    changed_when: false
+
+  - name: Build new_release_image_override from existing release_image_override(Without local-registry, oc-mirror )
+    set_fact:
+      new_release_image_override: "{{ release_image_override }}"
+    when:
+      - not ( qe_only_release_override | default(false) | bool )
+      - not ( enable_local_registry | default(false) | bool )
+
+  - name: Split release_image_override image into base and tag(for image with release tag)
+    set_fact:
+      base_image: "{{ release_image_override.rsplit(':', 1)[0] }}"
+      image_tag: "{{ release_image_override.rsplit(':', 1)[1] }}"
+    when: qe_only_release_override and enable_local_registry and oc_mirror_check.rc == 0
+
+  - name: Ensure base_image ends with /openshift/release-images
+    set_fact:
+      base_image: >-
+        {{ base_image if base_image.endswith('/openshift/release-images')
+          else base_image ~ '/openshift/release-images' }}
+    when: qe_only_release_override and enable_local_registry and oc_mirror_check.rc == 0
+
+  - name: Build new_release_image_override(local-registry and oc-mirror and tag based release image )
+    set_fact:
+      new_release_image_override: "{{ base_image }}:{{ image_tag }}"
+    when: qe_only_release_override and enable_local_registry and oc_mirror_check.rc == 0
+
   - name: Generate kdump machine configuration
     vars:
       kdump_sysconfig: |
@@ -120,7 +158,7 @@
     when: kdump.enabled
 
   - name: Create ignition files
-    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
+    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ new_release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"
 

--- a/playbooks/roles/ocp-config/templates/install-config.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/install-config.yaml.j2
@@ -30,10 +30,10 @@ additionalTrustBundle: |
 {{ lookup('file', '/opt/registry/certs/domain.crt') | indent(2, first=True) }}
 imageContentSources:
 - mirrors:
-  - registry.{{ install_config.cluster_id }}.{{ install_config.cluster_domain }}:5000/ocp4/openshift4
+  - registry.{{ install_config.cluster_id }}.{{ install_config.cluster_domain }}:5000/ocp4/openshift4/openshift/release-images
   source: quay.io/openshift-release-dev/ocp-release
 - mirrors:
-  - registry.{{ install_config.cluster_id }}.{{ install_config.cluster_domain }}:5000/ocp4/openshift4
+  - registry.{{ install_config.cluster_id }}.{{ install_config.cluster_domain }}:5000/ocp4/openshift4/openshift/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 {% else %}
 pullSecret: '{{ install_config.pull_secret }}'


### PR DESCRIPTION
This PR is for replacing "oc adm release mirror" command with "oc-mirror --v2" in disconnected installations.
This step is part of disconnected changes to get inline with current mirroring best practices.
Corresponding Redhat issue : https://issues.redhat.com/browse/OCPBUGS-70297