### PR TITLE
Add qe_only_disable_image_policy flag for QE testing

### DIFF
--- a/examples/install_vars.yaml
+++ b/examples/install_vars.yaml
@@ -10,6 +10,9 @@ storage_type: nfs
 log_level: info
 release_image_override: ""
 
+# IBM/Red Hat QE Only: Disables ClusterImagePolicy so Nightly builds can be deployed. This feature puts a cluster in unsupported mode.
+qe_only_disable_image_policy: false
+
 node_connection_timeout: 2700
 
 rhcos_pre_kernel_options: []

--- a/playbooks/bootstrap-complete.yaml
+++ b/playbooks/bootstrap-complete.yaml
@@ -14,6 +14,6 @@
   hosts: bastion[0]
   tasks:
   - name: Wait for bootstrap complete
-    shell: "openshift-install wait-for bootstrap-complete --log-level {{ log_level }}"
+    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} openshift-install wait-for bootstrap-complete --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"

--- a/playbooks/roles/ocp-config/defaults/main/main.yaml
+++ b/playbooks/roles/ocp-config/defaults/main/main.yaml
@@ -5,6 +5,9 @@ workdir: ~/ocp4-workdir
 rhcos_pre_kernel_options: []
 log_level: info
 release_image_override: ""
+
+# IBM/Red Hat QE Only: Disables ClusterImagePolicy so Nightly builds can be deployed. This feature puts a cluster in unsupported mode.
+qe_only_disable_image_policy: false
 proxy_url: ""
 no_proxy: ""
 enable_local_registry: false

--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -52,7 +52,7 @@
       force: yes
 
   - name: Generate manifest files
-    shell: "openshift-install create manifests --log-level {{ log_level }}"
+    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} openshift-install create manifests --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"
 
@@ -120,7 +120,7 @@
     when: kdump.enabled
 
   - name: Create ignition files
-    shell: "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
+    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"
 

--- a/playbooks/roles/ocp-install/defaults/main.yaml
+++ b/playbooks/roles/ocp-install/defaults/main.yaml
@@ -4,4 +4,7 @@
 workdir: ~/ocp4-workdir
 log_level: info
 release_image_override: ""
+
+# IBM/Red Hat QE Only: Disables ClusterImagePolicy so Nightly builds can be deployed. This feature puts a cluster in unsupported mode.
+qe_only_disable_image_policy: false
 storage_type: none

--- a/playbooks/roles/ocp-install/tasks/main.yaml
+++ b/playbooks/roles/ocp-install/tasks/main.yaml
@@ -21,7 +21,7 @@
   when: worker_count|int > 0
 
 - name: Wait for install-complete
-  shell: "openshift-install wait-for install-complete --log-level {{ log_level }}"
+  shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} openshift-install wait-for install-complete --log-level {{ log_level }}"
   args:
     chdir: "{{ workdir }}"
 


### PR DESCRIPTION
## Summary
This PR adds the `qe_only_disable_image_policy` flag to control the `OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY` environment variable during OpenShift installation.

## Purpose
This flag is specifically for QE testing purposes to disable image policy checks when needed for testing scenarios.

⚠️ **IMPORTANT: This is a QE-only feature and is NOT SUPPORTED for production use.**


CC: @prb112 @sudeeshjohn 