### PR TITLE
Remove OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY from bootstrap-complete.yaml

### DIFF
--- a/playbooks/bootstrap-complete.yaml
+++ b/playbooks/bootstrap-complete.yaml
@@ -14,6 +14,6 @@
   hosts: bastion[0]
   tasks:
   - name: Wait for bootstrap complete
-    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} openshift-install wait-for bootstrap-complete --log-level {{ log_level }}"
+    shell: "openshift-install wait-for bootstrap-complete --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"


### PR DESCRIPTION
Remove OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY from bootstrap-complete.yaml

The OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY environment variable is not needed for 'openshift-install wait-for bootstrap-complete' command as it only monitors/waits for the bootstrap process

This fixes the below issue:
```
module.bootstrapcomplete.null_resource.bootstrap_complete (remote-exec): fatal: [rdr-adi-noo-420-bastion-0]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'qe_only_disable_image_policy' is undefined. 'qe_only_disable_image_policy' is undefined\n\nThe error appears to be in '/root/ocp4-playbooks/playbooks/bootstrap-complete.yaml': line 16, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n  - name: Wait for bootstrap complete\n    ^ here\n"}
```
cc: @prb112 
