### PR TITLE
Add RHEL 10 DHCP support

### DIFF
--- a/playbooks/roles/ocp-config/tasks/dhcpd_update.yaml
+++ b/playbooks/roles/ocp-config/tasks/dhcpd_update.yaml
@@ -4,9 +4,18 @@
   shell: grep 'pool {' /etc/dhcp/dhcpd.conf
   ignore_errors: yes
   register: dhcp_pool
+  when: ansible_distribution_major_version | int < 10
 
-- name: Update DHCP server config
-  when: dhcp_pool.rc == 0
+- name: Find DHCP pool block for RHEL 10 and above
+  shell: jq -e '.Dhcp4.subnet4[].pools | length > 0' /etc/kea/kea-dhcp4.conf
+  ignore_errors: yes
+  register: dhcp_pool_rhel10
+  when: ansible_distribution_major_version | int >= 10
+
+- name: Update DHCP server config and restart the service
+  when:
+    - ansible_distribution_major_version | int < 10
+    - dhcp_pool.rc == 0
   block:
   - name: Remove pool, range and deny statements
     shell: |
@@ -20,5 +29,22 @@
     become: true
     service:
       name: dhcpd
+      state: restarted
+      enabled: yes
+
+- name: Update DHCP server config and restart the service for RHEL 10 and above
+  when:
+    - ansible_distribution_major_version | int >= 10
+    - dhcp_pool_rhel10.rc == 0
+  block:
+  - name: Remove pool, range and deny statements
+    shell: |
+      sudo jq ' .Dhcp4.authoritative = false | .Dhcp4.subnet4[].pools = [] ' /etc/kea/kea-dhcp4.conf | sudo tee /etc/kea/kea-dhcp4.conf.tmp >/dev/null
+      sudo mv /etc/kea/kea-dhcp4.conf.tmp /etc/kea/kea-dhcp4.conf
+
+  - name: restart kea-dhcp4
+    become: true
+    service:
+      name: kea-dhcp4
       state: restarted
       enabled: yes


### PR DESCRIPTION
Changes made for *[OPENSHIFTP-754](https://jsw.ibm.com/browse/OPENSHIFTP-754)*: OCP Automation: Support RHEL10/CentOS10

 - Incorporate new kea-dhcp package for RHEL 10 & above
 - Updates to the dhcp_pool variable and conditions.
 
 Verification done with RHEL10, RHEL9 & CentOS10 cluster deployment.
 
 Related PRs -
 ocp4-upi-powervm: https://github.com/ocp-power-automation/ocp4-upi-powervm/pull/303
ocp4-helpernode: https://github.com/redhat-cop/ocp4-helpernode/pull/338

 CC: @prb112 