### PR TITLE
fix: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY runs when present not just when true, this limits to when the qe_only_disable_image_policy is true, ensuring security is preserved

### DIFF
--- a/playbooks/roles/ocp-config/tasks/main.yaml
+++ b/playbooks/roles/ocp-config/tasks/main.yaml
@@ -51,8 +51,12 @@
       remote_src: yes
       force: yes
 
+  - name: Set disable image policy env prefix
+    set_fact:
+      disable_image_policy_env: "{{ 'OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY=true ' if qe_only_disable_image_policy else '' }}"
+
   - name: Generate manifest files
-    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} openshift-install create manifests --log-level {{ log_level }}"
+    shell: "{{ disable_image_policy_env }}openshift-install create manifests --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"
 
@@ -120,7 +124,7 @@
     when: kdump.enabled
 
   - name: Create ignition files
-    shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
+    shell: "{{ disable_image_policy_env }}OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ release_image_override }} openshift-install create ignition-configs --log-level {{ log_level }}"
     args:
       chdir: "{{ workdir }}"
 

--- a/playbooks/roles/ocp-install/tasks/main.yaml
+++ b/playbooks/roles/ocp-install/tasks/main.yaml
@@ -20,8 +20,12 @@
   delay: 30
   when: worker_count|int > 0
 
+- name: Set disable image policy env prefix
+  set_fact:
+    disable_image_policy_env: "{{ 'OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY=true ' if qe_only_disable_image_policy else '' }}"
+
 - name: Wait for install-complete
-  shell: "OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY={{ qe_only_disable_image_policy | lower }} openshift-install wait-for install-complete --log-level {{ log_level }}"
+  shell: "{{ disable_image_policy_env }}openshift-install wait-for install-complete --log-level {{ log_level }}"
   args:
     chdir: "{{ workdir }}"
 


### PR DESCRIPTION
fix: OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY runs when present not just when true, this limits to when the qe_only_disable_image_policy is true, ensuring security is preserved