### PR TITLE
fix: add featureSet TechPreviewNoUpgrade when os_image_stream is set

### DIFF
--- a/playbooks/roles/ocp-config/templates/install-config.yaml.j2
+++ b/playbooks/roles/ocp-config/templates/install-config.yaml.j2
@@ -24,6 +24,7 @@ platform:
   none: {}
 fips: {{ fips_compliant }}
 {% if install_config.os_image_stream is defined and install_config.os_image_stream != "" %}
+featureSet: TechPreviewNoUpgrade
 osImageStream: {{ install_config.os_image_stream }}
 {% endif %}
 sshKey: '{{ install_config.public_ssh_key }}'


### PR DESCRIPTION
Without the featureSet deployment fails saying featureSet is required when os_image_stream is set.